### PR TITLE
fix Size type value mapping

### DIFF
--- a/RE_RSZ.bt
+++ b/RE_RSZ.bt
@@ -1901,7 +1901,7 @@ typedef struct(uint32 classHash, uint16 fieldIndex) {
 		        case U64_tid:
 		        case Size_tid:
                     if (exists(r.data))
-                        SPrintf(s, "%g, %g", r.data);
+                        SPrintf(s, "%g, %g", r.data[0], r.data[1]);
                     break;
                 case F32_tid:
                     if (exists(r.data))

--- a/RE_RSZ.bt
+++ b/RE_RSZ.bt
@@ -1901,7 +1901,7 @@ typedef struct(uint32 classHash, uint16 fieldIndex) {
 		        case U64_tid:
 		        case Size_tid:
                     if (exists(r.data))
-                        SPrintf(s, "%Lu", r.data);
+                        SPrintf(s, "%g, %g", r.data);
                     break;
                 case F32_tid:
                     if (exists(r.data))
@@ -2120,7 +2120,6 @@ typedef struct(uint32 classHash, uint16 fieldIndex) {
                     else// if ()
                         WriteInt(pos, Atoi(s));
                     break;
-                case Size_tid:
 		        case S32_tid:
                     WriteInt(pos, Atoi(s)); break;
 		        case S64_tid:
@@ -2151,6 +2150,7 @@ typedef struct(uint32 classHash, uint16 fieldIndex) {
                 case Resource_tid:
                     WriteRSZString(r, s);
                     break;
+                case Size_tid:
                 case Vec2_tid:
                 case Range_tid:
                 case Float2_tid:

--- a/RE_RSZ.bt
+++ b/RE_RSZ.bt
@@ -1466,8 +1466,8 @@ typedef struct(uint32 classHash, uint16 fieldIndex) {
 				break;
 			case Size_tid:
 				fieldDataType = "Size";
-				if (FTell()+4 <= FileSize())
-				    uint data;
+				if (FTell()+8 <= FileSize())
+				    float data <name="float W">, data <name="float H">;
 				break;
 			case U16_tid:
 				fieldDataType = "UShort";


### PR DESCRIPTION
As Size_tid from TypeCode is `via.Size` type, which the field inside it is 
```cs
    [expose]public  System.Single w;
    [expose]public  System.Single h;
```
So I fix it to two float

(verified with some user.2 file actually using the Size_tid)