### PR TITLE
Autorun support for .user.3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Uses a DLL and large JSON files to know how to parse the structures of each game
 
 # Supported Games:
 - Apollo Justice: Ace Attorney Trilogy
+- Dead Rising Deluxe Remaster
 - Devil May Cry 5
 - Dragon's Dogma 2
 - Ghost Trick

--- a/RE_RSZ.bt
+++ b/RE_RSZ.bt
@@ -7,9 +7,9 @@
 //   Version: 0.87
 //   Purpose: Parsing RE Engine RSZ data
 //  Category: RE Engine
-// File Mask: *.user.2;*.pfb.*;*.scn.*;*.rcol.*;*.bhvt.*;*.motfsm2.*;*.fsmv2.*;*.fchar.*
+// File Mask: *.user.*;*.pfb.*;*.scn.*;*.rcol.*;*.bhvt.*;*.motfsm2.*;*.fsmv2.*;*.fchar.*
 //  ID Bytes: 
-//   History: Sept 26, 2024
+//   History: Sept 29, 2024
 //      Note: It is recommended to use this template with 010 Editor v9.0.2 or v10.0.2, to avoid crashes, particulary when using RE_RSZ_ChangeValues.1sc
 //------------------------------------------------
 //              Option:                                                             //Effect:


### PR DESCRIPTION
A very minor change but DRDR is using `.user.3` instead of `.user.2` also updated the readme to be up to date.