### PR TITLE
Fix: GameObject attributes 'prefabId' & 'ukn' are inverted in scn.18/19

### DIFF
--- a/RE_RSZ.bt
+++ b/RE_RSZ.bt
@@ -4792,8 +4792,16 @@ if (ReadUInt(0) != id_RCOL) { //no RCOL
                         ObjectId id(0);
                         ObjectId parentId(0);
                         ushort componentCount;
-                        short ukn;
-                        int prefabId;
+                        if((RSZVersion == "RE7" && !RTVersion) || (!RTVersion && RSZVersion == "RE2") || RSZVersion == "DMC5")
+                        {
+                            short prefabId;
+                            int ukn;
+                        }
+                        else
+                        {
+                            short ukn;
+                            int prefabId;
+                        }
                     }
                     FSkip(-2);
                     //ubyte AddGameObjectOffset <read=ReadGameObjectsOffset>;


### PR DESCRIPTION
In older SCN files, the current 'ukn' holds the actual prefab id and vice versa. 
To avoid confusion, I have swapped them for the 3 games where it applies (DMC5, RE2 non-rt and RE7 non-rt).
The first field remains a `short`, the second an `int`.