### PR TITLE
Fix RE9 json path detection.

### DIFF
--- a/RE_RSZ.bt
+++ b/RE_RSZ.bt
@@ -38,6 +38,7 @@ local wstring RE3Path <hidden=true>      =              "F:\\modmanager\\REtool\
 local wstring RE4Path <hidden=true>      =              "H:\\modding\\REtool\\RE4demo_chunk_000\\natives\\stm\\";
 local wstring RE7Path <hidden=true>      =              "F:\\modmanager\\REtool\\RE7_chunk_000\\natives\\x64\\";
 local wstring RE8Path <hidden=true>      =              "F:\\modmanager\\REtool\\RE8_chunk_000\\natives\\stm\\";
+local wstring RE9Path <hidden=true>      =              "F:\\modmanager\\REtool\\RE9_chunk_000\\natives\\stm\\";
 local wstring MHRPath <hidden=true>      =              "F:\\modmanager\\REtool\\MHR_chunk_000\\natives\\stm\\";
 local wstring RE2RTPath <hidden=true>    =              "F:\\modmanager\\REtool\\RE2RT_chunk_000\\natives\\stm\\";
 local wstring RE3RTPath <hidden=true>    =              "F:\\modmanager\\REtool\\RE3RT_chunk_000\\natives\\stm\\";
@@ -174,6 +175,11 @@ if (AutoDetectGame) {
 	    extractedDir = Lower(RE8Path);
 	    xFmt = "stm\\";
         Printf("Detected RE8 in filepath\n");
+    } else if (find(dir, "re9") != -1 || find(dir, "evil requ") != -1 || find(dir, "requiem") != -1) {
+	    RSZVersion = "RE9"; o = 1;
+	    extractedDir = Lower(RE9Path);
+	    xFmt = "stm\\";
+        Printf("Detected RE9 in filepath\n");
     } else if (find(dir, "re7") != -1 || find(dir, "evil 7") != -1) {
 	    RSZVersion = "RE7"; o = 1;
         if (RTVersion) {
@@ -313,6 +319,7 @@ void AutoDetectVersion() {
                         case 8: RSZVersion = "DD2"; extractedDir = DD2Path; xFmt = "stm\\"; break;
                         case 9: RSZVersion = "DRDR"; extractedDir = DRDRPath; xFmt = "stm\\"; break;
                         case 10: RSZVersion = "MHWilds"; extractedDir = MHWSPath; xFmt = "stm\\"; break;
+                        case 11: RSZVersion = "RE9"; extractedDir = RE9Path; xFmt = "stm\\"; break;
                         default: break;
                     }
                     


### PR DESCRIPTION
Just adds path detection so the json loads from something like `V:\RE9\re_chunk_000\natives`.

(I'm not sure *all* the changes here are needed, but it does work when tested.)